### PR TITLE
#2 Add .NET Core Github Action to build CatApi project

### DIFF
--- a/.github/workflows/build-catapi.yml
+++ b/.github/workflows/build-catapi.yml
@@ -1,0 +1,21 @@
+name: Build CatAPI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.202
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
Added .net core 2.0 action to build project as simple check. Used default Ubuntu environment for build. 